### PR TITLE
Updated plugin to use google 2.0 package.

### DIFF
--- a/lib/sourcerer.coffee
+++ b/lib/sourcerer.coffee
@@ -47,14 +47,14 @@ searchGoogle = (query, language) ->
 
     searchString = "#{query} in #{language} site:stackoverflow.com"
     console.log "SEARCHING: #{searchString}"
-    google searchString, (err, next, links) ->
+    google searchString, (err, res) ->
       if err
         reject reason: "An error has occured"
 
-      if links.length == 0
+      if res.links.length == 0
         reject reason: "No results were found"
 
-      soLinks = links.map (item) -> item.link
+      soLinks = res.links.map (item) -> item.link
       resolve soLinks
 
 
@@ -65,6 +65,7 @@ module.exports =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       'sourcerer:fetch': => @fetch()
+
 
   deactivate: ->
     @subscriptions.dispose()
@@ -78,6 +79,9 @@ module.exports =
         return
 
       language = editor.getGrammar().name
+
+      google "test", (err,next,link) ->
+        console.log err,next,link
 
       searchGoogle(selection, language)
       .then (soLinks) ->

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "google": "*",
+    "google": ">2.0.0",
     "cheerio": "*",
     "request": "*"
   }


### PR DESCRIPTION
Both next and links are now passed in a single result object, instead of separate.

Due to the fact that the package didn't care about google's version, it worked for google versions <2.0.0 and broke for the newer ones.
