### PR TITLE
Made the gif url absolute to fix broken display

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Sourcerer
 
 Atom plugin for quickly finding and using StackOverflow code snippets. 
 
-![](/screenshots/sourcerer.gif)
+![](https://raw.githubusercontent.com/NickTikhonov/sourcerer/master/screenshots/sourcerer.gif)
 
 Find and use code snippets relevant to your problem. Replace routine StackOverflow searching with a simple interface for searching and browsing the largest code snippet collection on the internet :)
 


### PR DESCRIPTION
A relative URL to the gif doesn't work in atom or at atom.io.
